### PR TITLE
CustomResourcePositionForFocusedView

### DIFF
--- a/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
@@ -88,16 +88,13 @@ class ShowcaseView @JvmOverloads constructor(
 
         listenClickEvents()
         val arrowPosition = TooltipFieldUtil.decideArrowPosition(showcaseModel, resources.getHeightInPixels())
-        val arrowMargin = TooltipFieldUtil.calculateArrowMargin(
-            horizontalCenter = showcaseModel.horizontalCenter(),
-            density = resources.getDensity()
-        )
+        val arrowStartMargin = showcaseModel.horizontalCenter().toInt()
         val marginFromBottom = getMarginFromBottom(showcaseModel, arrowPosition)
         val showcaseViewState = ShowcaseViewState(margin = marginFromBottom)
         val tooltipViewState = TooltipViewState(
             showcaseModel = showcaseModel,
             arrowPosition = arrowPosition,
-            arrowMargin = arrowMargin
+            arrowMargin = arrowStartMargin
         )
         setCustomContent()
 

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
@@ -8,7 +8,6 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2
 import com.trendyol.showcase.R
@@ -21,13 +20,15 @@ import com.trendyol.showcase.ui.setTint
 import com.trendyol.showcase.ui.slidablecontent.SlidableContent
 import com.trendyol.showcase.ui.slidablecontent.SlidableContentAdapter
 import com.trendyol.showcase.util.ActionType
+import com.trendyol.showcase.util.TooltipFieldUtil.calculateStartMarginForArrow
 
 class TooltipView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
 ) : ConstraintLayout(context, attrs) {
 
-    private val binding = LayoutTooltipBinding.inflate(LayoutInflater.from(context), rootView as ViewGroup)
+    private val binding =
+        LayoutTooltipBinding.inflate(LayoutInflater.from(context), rootView as ViewGroup)
     private var clickListener: ((ActionType, Int) -> (Unit))? = null
 
     init {
@@ -72,13 +73,12 @@ class TooltipView @JvmOverloads constructor(
             with(imageViewTopArrow) {
                 visibility = tooltipViewState.getTopArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
-                val drawable = requireNotNull(
-                    ContextCompat.getDrawable(
-                        context,
-                        tooltipViewState.getTopArrowResource()
-                    )
+
+                val imageStartMargin = calculateStartMarginForArrow(
+                    tooltipViewState.arrowMargin,
+                    tooltipViewState.getTopArrowResource(),
+                    context
                 )
-                val imageStartMargin = tooltipViewState.arrowMargin - (drawable.intrinsicWidth) / 2
                 layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
                 setImageDrawable(drawable)
             }
@@ -98,13 +98,11 @@ class TooltipView @JvmOverloads constructor(
             with(imageViewBottomArrow) {
                 visibility = tooltipViewState.getBottomArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
-                val drawable = requireNotNull(
-                    ContextCompat.getDrawable(
-                        context,
-                        tooltipViewState.getBottomArrowResource()
-                    )
+                val imageStartMargin = calculateStartMarginForArrow(
+                    tooltipViewState.arrowMargin,
+                    tooltipViewState.getBottomArrowResource(),
+                    context
                 )
-                val imageStartMargin = tooltipViewState.arrowMargin - (drawable.intrinsicWidth) / 2
                 layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
                 setImageDrawable(drawable)
             }

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
@@ -3,11 +3,13 @@ package com.trendyol.showcase.ui.tooltip
 import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2
 import com.trendyol.showcase.R
@@ -74,10 +76,15 @@ class TooltipView @JvmOverloads constructor(
                 visibility = tooltipViewState.getTopArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
 
+                val drawable: Drawable = requireNotNull(
+                    ContextCompat.getDrawable(
+                        context,
+                        tooltipViewState.getTopArrowResource()
+                    )
+                )
                 val imageStartMargin = calculateStartMarginForArrow(
                     tooltipViewState.arrowMargin,
-                    tooltipViewState.getTopArrowResource(),
-                    context
+                    drawable
                 )
                 layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
                 setImageDrawable(drawable)
@@ -98,10 +105,15 @@ class TooltipView @JvmOverloads constructor(
             with(imageViewBottomArrow) {
                 visibility = tooltipViewState.getBottomArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
+                val drawable: Drawable = requireNotNull(
+                    ContextCompat.getDrawable(
+                        context,
+                        tooltipViewState.getBottomArrowResource()
+                    )
+                )
                 val imageStartMargin = calculateStartMarginForArrow(
                     tooltipViewState.arrowMargin,
-                    tooltipViewState.getBottomArrowResource(),
-                    context
+                    drawable
                 )
                 layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
                 setImageDrawable(drawable)

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
@@ -72,8 +72,15 @@ class TooltipView @JvmOverloads constructor(
             with(imageViewTopArrow) {
                 visibility = tooltipViewState.getTopArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
-                layoutMarginStart(tooltipViewState.arrowMargin, tooltipViewState.getArrowPercentage())
-                setImageDrawable(ContextCompat.getDrawable(context, tooltipViewState.getTopArrowResource()))
+                val drawable = requireNotNull(
+                    ContextCompat.getDrawable(
+                        context,
+                        tooltipViewState.getTopArrowResource()
+                    )
+                )
+                val imageStartMargin = tooltipViewState.arrowMargin - (drawable.intrinsicWidth) / 2
+                layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
+                setImageDrawable(drawable)
             }
             layoutContents.isClickable = tooltipViewState.isShowcaseViewClickable()
             cardContent.visibility = tooltipViewState.getContentVisibility()
@@ -91,8 +98,15 @@ class TooltipView @JvmOverloads constructor(
             with(imageViewBottomArrow) {
                 visibility = tooltipViewState.getBottomArrowVisibility()
                 setTint(tooltipViewState.getBackgroundColor())
-                layoutMarginStart(tooltipViewState.arrowMargin, tooltipViewState.getArrowPercentage())
-                setImageDrawable(ContextCompat.getDrawable(context, tooltipViewState.getBottomArrowResource()))
+                val drawable = requireNotNull(
+                    ContextCompat.getDrawable(
+                        context,
+                        tooltipViewState.getBottomArrowResource()
+                    )
+                )
+                val imageStartMargin = tooltipViewState.arrowMargin - (drawable.intrinsicWidth) / 2
+                layoutMarginStart(imageStartMargin, tooltipViewState.getArrowPercentage())
+                setImageDrawable(drawable)
             }
         }
     }

--- a/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
@@ -3,7 +3,6 @@ package com.trendyol.showcase.util
 import android.content.Context
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
-import androidx.core.content.ContextCompat
 import com.trendyol.showcase.showcase.ShowcaseModel
 import com.trendyol.showcase.ui.tooltip.AbsoluteArrowPosition
 import com.trendyol.showcase.ui.tooltip.ArrowPosition
@@ -72,8 +71,7 @@ internal object TooltipFieldUtil {
         }
     }
 
-    fun calculateStartMarginForArrow(arrowMargin: Int, resource: Int, context: Context): Int {
-        val drawable: Drawable = requireNotNull(ContextCompat.getDrawable(context, resource))
-        return arrowMargin - (drawable.intrinsicWidth) / 2
+    fun calculateStartMarginForArrow(arrowMargin: Int, resource: Drawable): Int {
+        return arrowMargin - (resource.intrinsicWidth) / 2
     }
 }

--- a/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
@@ -1,6 +1,9 @@
 package com.trendyol.showcase.util
 
+import android.content.Context
 import android.graphics.Rect
+import android.graphics.drawable.Drawable
+import androidx.core.content.ContextCompat
 import com.trendyol.showcase.showcase.ShowcaseModel
 import com.trendyol.showcase.ui.tooltip.AbsoluteArrowPosition
 import com.trendyol.showcase.ui.tooltip.ArrowPosition
@@ -9,14 +12,23 @@ import kotlin.math.sqrt
 
 internal object TooltipFieldUtil {
 
-    fun decideArrowPosition(showcaseModel: ShowcaseModel, screenHeight: Int): AbsoluteArrowPosition =
+    fun decideArrowPosition(
+        showcaseModel: ShowcaseModel,
+        screenHeight: Int
+    ): AbsoluteArrowPosition =
         when (showcaseModel.arrowPosition) {
             ArrowPosition.UP -> AbsoluteArrowPosition.UP
             ArrowPosition.DOWN -> AbsoluteArrowPosition.DOWN
-            ArrowPosition.AUTO -> calculateArrowPosition(showcaseModel.verticalCenter(), screenHeight)
+            ArrowPosition.AUTO -> calculateArrowPosition(
+                showcaseModel.verticalCenter(),
+                screenHeight
+            )
         }
 
-    private fun calculateArrowPosition(verticalCenter: Float, screenHeight: Int): AbsoluteArrowPosition =
+    private fun calculateArrowPosition(
+        verticalCenter: Float,
+        screenHeight: Int
+    ): AbsoluteArrowPosition =
         if (screenHeight / 2 > verticalCenter) {
             AbsoluteArrowPosition.UP
         } else {
@@ -58,5 +70,10 @@ internal object TooltipFieldUtil {
             val diff = if (isStatusBarVisible) -statusBarHeight else 0
             (screenHeight - top + diff).toInt()
         }
+    }
+
+    fun calculateStartMarginForArrow(arrowMargin: Int, resource: Int, context: Context): Int {
+        val drawable: Drawable = requireNotNull(ContextCompat.getDrawable(context, resource))
+        return arrowMargin - (drawable.intrinsicWidth) / 2
     }
 }

--- a/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/TooltipFieldUtil.kt
@@ -59,10 +59,4 @@ internal object TooltipFieldUtil {
             (screenHeight - top + diff).toInt()
         }
     }
-
-    fun calculateArrowMargin(horizontalCenter: Float, density: Float): Int {
-        val arrowHalfWidth = (15 * density)
-
-        return (horizontalCenter - arrowHalfWidth).toInt()
-    }
 }


### PR DESCRIPTION
<img src="https://github.com/Trendyol/showcase/assets/38102876/eb589450-909a-497e-bbb7-98b87f812a2b" height="600" /> 
<img src="https://github.com/Trendyol/showcase/assets/38102876/73939ada-23ab-4c6c-a408-f25a035b4dd3" height="600" /> <br>

When we give an custom arrow, the arrowhead doesn't exactly match the focused view. Because in the library, we have a variable as val `arrowHalfWidth = (15 * density) ` 15 means the default drawable resource width value. So its not developed as generic usages. In screenshots, I used custom drawable with width value is 10dp. So, we figure out that there is an problem in here. So we fix the problem with ` val imageStartMargin = tooltipViewState.arrowMargin - (drawable.intrinsicWidth) / 2` usage.