### PR TITLE
Rotate arrow head

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,47 +66,47 @@ showcaseManager.show(context) // or showcaseManager.show(context, REQUEST_CODE_S
 
 ### Builder Configuration
 
-| Usage                                                   | Description                                              | Optional | Default Value                | StyleRes |
-|:--------------------------------------------------------|:---------------------------------------------------------|:---------|:-----------------------------|:---------|
-| `builder.focus(View)`                                   | view to be focused on                                    | no       | null                         | no       |
-| `builder.focus(Array<View>)`                            | view array to be focused on                              | no       | null                         | no       |
-| `builder.resId(Int)`                                    | Showcase.Theme style                                     | yes      | null                         | yes      |
-| `builder.titleText(String)`                             | text to be showed on top of the tooltip                  | yes      | ""                           | no       |
-| `builder.descriptionText(String)`                       | description text will be displayed on tooltip            | yes      | ""                           | no       |
-| `builder.titleTextColor(Int)`                           | titleText's color                                        | yes      | Color.BLACK                  | yes      |
-| `builder.descriptionTextColor(Int)`                     | descriptionText's color                                  | yes      | Color.BLACK                  | yes      |
-| `builder.titleTextSize(Int)`                            | titleText's text size in SP                              | yes      | 18 SP                        | no       |
-| `builder.descriptionTextSize(Int)`                      | descriptionText's text size in SP                        | yes      | 14 SP                        | no       |
-| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily                                   | yes      | sans-serif                   | yes      |
-| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily                             | yes      | sans-serif                   | yes      |
-| `builder.titleTextStyle(Int)`                           | titleText's textStyle                                    | yes      | Typeface.NORMAL              | yes      |
-| `builder.descriptionTextStyle(Int)`                     | descriptionText's textStyle                              | yes      | Typeface.NORMAL              | yes      |
-| `builder.backgroundColor(Int)`                          | background color of tooltip                              | yes      | Color.WHITE                  | yes      |
-| `builder.closeButtonColor(Int)`                         | closeButton's color                                      | yes      | Color.BLACK                  | yes      |
-| `builder.showCloseButton(Boolean)`                      | show close button on tooltip                             | yes      | true                         | yes      |
-| `builder.arrowResource(Int)`                            | custom icon resource for arrow.                          | yes      | ic_arrow_down or ic_arrow_up | no       |
-| `builder.arrowPosition(ArrowPosition)`                  | arrow can be placed under or over the tooltip            | yes      | ArrowPosition.AUTO           | no       |
-| `builder.arrowPercentage(Int)`                          | arrow position percentage can be decided                 | yes      | null                         | no       |
-| `builder.highlightType(HighlightType)`                  | view can be highlighted with a circle shape or rectangle | yes      | HighlightType.RECTANGLE      | no       |
-| `builder.cancelListener(CancelListener)`                | will be called after user quit from tooltip              | yes      | null                         | no       |
-| `builder.windowBackgroundColor(Int)`                    | background of the window's color can be decided          | yes      | Color.BLACK                  | yes      |
-| `builder.windowBackgroundTint(Int)`                     | alpha value of window's background color                 | yes      | 204                          | no       |
-| `builder.titleTextSize(Int)`                            | titleText's text size in SP                              | yes      | 18                           | no       |
-| `builder.cancellableFromOutsideTouch(Boolean)`          | outside touch from tooltip will act as close click       | yes      | false                        | yes      |
-| `builder.showcaseViewClickable(Boolean)`                | makes the showcase view clickable or not                 | yes      | false                        | yes      |
-| `builder.isDebugMode(Boolean)`                          | tooltip won't be presented                               | yes      | false                        | no       |
-| `builder.attachOnParentLifecycle(Boolean)`              | observe parent lifecycle and dismiss showcase            | yes      | false                        | no       |
-| `builder.textPosition(TextPosition)`                    | text can be positioning center, end and start            | yes      | TextPosition.START           | no       |
-| `builder.imageUrl(String)`                              | show image on tooltip                                    | yes      | null                         | no       |
-| `builder.customContent(Int)`                            | show given layout                                        | yes      | null                         | no       |
-| `builder.statusBarVisible(Boolean)`                     | statusBar visibility of window                           | yes      | true                         | no       |
-| `builder.toolTipVisible(Boolean)`                       | tooltip visibility                                       | yes      | true                         | no       |
-| `builder.highlightRadius(Float, Float, Float, Float)`   | tooltip visibility                                       | yes      | 0f, 0f, 0f, 0f               | no       |
-| `builder.setSlidableContentList(List<SlidableContent>)` | show slidable content                                    | yes      | null                         | no       |  
-| `builder.showDurationMillis(Long)`                      | duration of the tooltip visibility                       | yes      | 2000L                        | no       |
-| `builder.showcaseViewVisibleIndefinitely(Boolean)`      | controls tooltip visibility condition                    | yes      | true                         | no       |
-| `builder.build()`                                       | will return ShowcaseManager instance                     | no       |                              |          |
-| `showcaseManager.show(Context)`                         | show the tooltip with set attributes on                  | no       |                              |          |
+| Usage                                                   | Description                                                                      | Optional | Default Value               | StyleRes |
+|:--------------------------------------------------------|:---------------------------------------------------------------------------------|:---------|:----------------------------|:---------|
+| `builder.focus(View)`                                   | view to be focused on                                                            | no       | null                        | no       |
+| `builder.focus(Array<View>)`                            | view array to be focused on                                                      | no       | null                        | no       |
+| `builder.resId(Int)`                                    | Showcase.Theme style                                                             | yes      | null                        | yes      |
+| `builder.titleText(String)`                             | text to be showed on top of the tooltip                                          | yes      | ""                          | no       |
+| `builder.descriptionText(String)`                       | description text will be displayed on tooltip                                    | yes      | ""                          | no       |
+| `builder.titleTextColor(Int)`                           | titleText's color                                                                | yes      | Color.BLACK                 | yes      |
+| `builder.descriptionTextColor(Int)`                     | descriptionText's color                                                          | yes      | Color.BLACK                 | yes      |
+| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                      | yes      | 18 SP                       | no       |
+| `builder.descriptionTextSize(Int)`                      | descriptionText's text size in SP                                                | yes      | 14 SP                       | no       |
+| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily                                                           | yes      | sans-serif                  | yes      |
+| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily                                                     | yes      | sans-serif                  | yes      |
+| `builder.titleTextStyle(Int)`                           | titleText's textStyle                                                            | yes      | Typeface.NORMAL             | yes      |
+| `builder.descriptionTextStyle(Int)`                     | descriptionText's textStyle                                                      | yes      | Typeface.NORMAL             | yes      |
+| `builder.backgroundColor(Int)`                          | background color of tooltip                                                      | yes      | Color.WHITE                 | yes      |
+| `builder.closeButtonColor(Int)`                         | closeButton's color                                                              | yes      | Color.BLACK                 | yes      |
+| `builder.showCloseButton(Boolean)`                      | show close button on tooltip                                                     | yes      | true                        | yes      |
+| `builder.arrowResource(Int)`                            | custom icon resource for the arrow rotates 180° if the arrow position is bottom  | yes      | ic_arrow_up                 | no       |
+| `builder.arrowPosition(ArrowPosition)`                  | arrow can be placed under or over the tooltip                                    | yes      | ArrowPosition.AUTO          | no       |
+| `builder.arrowPercentage(Int)`                          | arrow position percentage can be decided                                         | yes      | null                        | no       |
+| `builder.highlightType(HighlightType)`                  | view can be highlighted with a circle shape or rectangle                         | yes      | HighlightType.RECTANGLE     | no       |
+| `builder.cancelListener(CancelListener)`                | will be called after user quit from tooltip                                      | yes      | null                        | no       |
+| `builder.windowBackgroundColor(Int)`                    | background of the window's color can be decided                                  | yes      | Color.BLACK                 | yes      |
+| `builder.windowBackgroundTint(Int)`                     | alpha value of window's background color                                         | yes      | 204                         | no       |
+| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                      | yes      | 18                          | no       |
+| `builder.cancellableFromOutsideTouch(Boolean)`          | outside touch from tooltip will act as close click                               | yes      | false                       | yes      |
+| `builder.showcaseViewClickable(Boolean)`                | makes the showcase view clickable or not                                         | yes      | false                       | yes      |
+| `builder.isDebugMode(Boolean)`                          | tooltip won't be presented                                                       | yes      | false                       | no       |
+| `builder.attachOnParentLifecycle(Boolean)`              | observe parent lifecycle and dismiss showcase                                    | yes      | false                       | no       |
+| `builder.textPosition(TextPosition)`                    | text can be positioning center, end and start                                    | yes      | TextPosition.START          | no       |
+| `builder.imageUrl(String)`                              | show image on tooltip                                                            | yes      | null                        | no       |
+| `builder.customContent(Int)`                            | show given layout                                                                | yes      | null                        | no       |
+| `builder.statusBarVisible(Boolean)`                     | statusBar visibility of window                                                   | yes      | true                        | no       |
+| `builder.toolTipVisible(Boolean)`                       | tooltip visibility                                                               | yes      | true                        | no       |
+| `builder.highlightRadius(Float, Float, Float, Float)`   | tooltip visibility                                                               | yes      | 0f, 0f, 0f, 0f              | no       |
+| `builder.setSlidableContentList(List<SlidableContent>)` | show slidable content                                                            | yes      | null                        | no       |  
+| `builder.showDurationMillis(Long)`                      | duration of the tooltip visibility                                               | yes      | 2000L                       | no       |
+| `builder.showcaseViewVisibleIndefinitely(Boolean)`      | controls tooltip visibility condition                                            | yes      | true                        | no       |
+| `builder.build()`                                       | will return ShowcaseManager instance                                             | no       |                             |          |
+| `showcaseManager.show(Context)`                         | show the tooltip with set attributes on                                          | no       |                             |          |
 
 ### Action Result
 

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
@@ -79,7 +79,7 @@ class TooltipView @JvmOverloads constructor(
                 val drawable: Drawable = requireNotNull(
                     ContextCompat.getDrawable(
                         context,
-                        tooltipViewState.getTopArrowResource()
+                        tooltipViewState.getArrowResource()
                     )
                 )
                 val imageStartMargin = calculateStartMarginForArrow(
@@ -108,9 +108,10 @@ class TooltipView @JvmOverloads constructor(
                 val drawable: Drawable = requireNotNull(
                     ContextCompat.getDrawable(
                         context,
-                        tooltipViewState.getBottomArrowResource()
+                        tooltipViewState.getArrowResource()
                     )
                 )
+                rotation = 180F
                 val imageStartMargin = calculateStartMarginForArrow(
                     tooltipViewState.arrowMargin,
                     drawable

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
@@ -55,9 +55,6 @@ internal data class TooltipViewState(
 
     fun getTopArrowVisibility() = if (arrowPosition == AbsoluteArrowPosition.UP) View.VISIBLE else View.GONE
 
-    fun getBottomArrowResource() =
-        if (showcaseModel.arrowResource == Constants.DEFAULT_ARROW_RESOURCE) R.drawable.ic_showcase_arrow_down else showcaseModel.arrowResource
-
     fun getBottomArrowVisibility() = if (arrowPosition == AbsoluteArrowPosition.DOWN) View.VISIBLE else View.GONE
 
     fun getCloseButtonColor() = showcaseModel.closeButtonColor

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
@@ -50,7 +50,7 @@ internal data class TooltipViewState(
 
     fun getArrowPercentage() = showcaseModel.arrowPercentage
 
-    fun getTopArrowResource() =
+    fun getArrowResource() =
         if (showcaseModel.arrowResource == Constants.DEFAULT_ARROW_RESOURCE) R.drawable.ic_showcase_arrow_up else showcaseModel.arrowResource
 
     fun getTopArrowVisibility() = if (arrowPosition == AbsoluteArrowPosition.UP) View.VISIBLE else View.GONE

--- a/library/src/main/res/drawable/ic_showcase_arrow_down.xml
+++ b/library/src/main/res/drawable/ic_showcase_arrow_down.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="30dp"
-    android:height="15dp"
-    android:viewportWidth="10.0"
-    android:viewportHeight="5.0">
-    <path
-        android:fillColor="#FF000000"
-        android:pathData="M0,0l5,5 5,-5z" />
-</vector>

--- a/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateFactory.kt
+++ b/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateFactory.kt
@@ -17,7 +17,7 @@ internal object TooltipViewStateFactory {
         backgroundColor: Int = Color.WHITE,
         closeButtonColor: Int = Color.BLACK,
         showCloseButton: Boolean = true,
-        arrowResource: Int = R.drawable.ic_showcase_arrow_down,
+        arrowResource: Int = R.drawable.ic_showcase_arrow_up,
         arrowPosition: ArrowPosition = ArrowPosition.DOWN,
         absoluteArrowPosition: AbsoluteArrowPosition = AbsoluteArrowPosition.DOWN,
         arrowPercentage: Int = 50,

--- a/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateTest.kt
+++ b/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateTest.kt
@@ -125,7 +125,7 @@ class TooltipViewStateTest {
 
         //then
         val expectedResult = R.drawable.ic_showcase_arrow_up
-        val actualResult = tooltipViewState.getTopArrowResource()
+        val actualResult = tooltipViewState.getArrowResource()
 
         actualResult `should be` expectedResult
     }
@@ -137,7 +137,7 @@ class TooltipViewStateTest {
         val tooltipViewState = TooltipViewStateFactory.provideTooltipViewState(arrowResource = givenArrowResource)
 
         //then
-        val actualResult = tooltipViewState.getTopArrowResource()
+        val actualResult = tooltipViewState.getArrowResource()
 
         actualResult `should be` givenArrowResource
     }
@@ -164,30 +164,6 @@ class TooltipViewStateTest {
         val actualResult = tooltipViewState.getTopArrowVisibility()
 
         actualResult `should be` expectedResult
-    }
-
-    @Test
-    fun `when arrowResource is DEFAULT_ARROW_RESOURCE then getBottomArrowResource() returns ic_arrow_down`() {
-        //when
-        val tooltipViewState = TooltipViewStateFactory.provideTooltipViewState(arrowResource = DEFAULT_ARROW_RESOURCE)
-
-        //then
-        val expectedResult = R.drawable.ic_showcase_arrow_down
-        val actualResult = tooltipViewState.getBottomArrowResource()
-
-        actualResult `should be` expectedResult
-    }
-
-    @Test
-    fun `when arrowResource is not DEFAULT_ARROW_RESOURCE then getBottomArrowResource() returns arrowResource`() {
-        //when
-        val givenArrowResource = android.R.drawable.arrow_down_float
-        val tooltipViewState = TooltipViewStateFactory.provideTooltipViewState(arrowResource = givenArrowResource)
-
-        //then
-        val actualResult = tooltipViewState.getBottomArrowResource()
-
-        actualResult `should be` givenArrowResource
     }
 
     @Test


### PR DESCRIPTION
When we set a custom arrow resource and showcase is displaying above the view,  arrowhead is not rotating. 
<img width="200" alt="image" src="https://github.com/Trendyol/showcase/assets/56167652/d6261f9a-eb35-464d-88b6-7943e9d3cc72">

I had two solutions for this issue;

1. Add top and bottom arrow resources to the ShowCase builder
2. Remove the bottom and top arrow source separation.

I've selected the second one, cause the bottom resource is actually the same but upside down 😄 . 

https://github.com/Trendyol/showcase/assets/56167652/e4397ab3-33f9-4440-9a32-38bc2be1ffc8

