### PR TITLE
Fix Arrow StartMargin for RTL

### DIFF
--- a/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
@@ -18,6 +18,8 @@ import com.trendyol.showcase.util.OnTouchClickListener
 import com.trendyol.showcase.util.TooltipFieldUtil
 import com.trendyol.showcase.util.getDensity
 import com.trendyol.showcase.util.getHeightInPixels
+import com.trendyol.showcase.util.isRTL
+import com.trendyol.showcase.util.screenWidth
 import com.trendyol.showcase.util.shape.CircleShape
 import com.trendyol.showcase.util.shape.RectangleShape
 import com.trendyol.showcase.util.statusBarHeight
@@ -88,7 +90,11 @@ class ShowcaseView @JvmOverloads constructor(
 
         listenClickEvents()
         val arrowPosition = TooltipFieldUtil.decideArrowPosition(showcaseModel, resources.getHeightInPixels())
-        val arrowStartMargin = showcaseModel.horizontalCenter().toInt()
+        val arrowStartMargin = if (context.isRTL()) {
+            context.screenWidth() - showcaseModel.horizontalCenter().toInt()
+        } else {
+            showcaseModel.horizontalCenter().toInt()
+        }
         val marginFromBottom = getMarginFromBottom(showcaseModel, arrowPosition)
         val showcaseViewState = ShowcaseViewState(margin = marginFromBottom)
         val tooltipViewState = TooltipViewState(

--- a/library/src/main/java/com/trendyol/showcase/util/CommonExtensions.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/CommonExtensions.kt
@@ -1,11 +1,23 @@
 package com.trendyol.showcase.util
 
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Rect
 import android.graphics.RectF
+import android.util.DisplayMetrics
+import android.view.View
+import android.view.WindowManager
 
 internal fun Rect.toRectF() = RectF(left.toFloat(), top.toFloat(), right.toFloat(), bottom.toFloat())
 
 internal fun Resources.getHeightInPixels() = displayMetrics.heightPixels
 
 internal fun Resources.getDensity() = displayMetrics.density
+
+internal fun Context.isRTL() = resources.configuration.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
+internal fun Context.screenWidth(): Int {
+    val windowManager = getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    val displayMetrics = DisplayMetrics().also { windowManager.defaultDisplay.getMetrics(it) }
+    return displayMetrics.widthPixels
+}


### PR DESCRIPTION
Arrow' `startMargin` was set to be the distance from the left side of the screen. This was causing a placement bug in RTL devices. 

**Solution**
`arrowStartMargin` is changed to be the distance from the right side of the screen for RTL devices. 
We keep using `this.marginStart = margin` as start of the view is changed to be right for RTL.

## Screenshots Before & After Fix

| **Before Fix**  | **After Fix**  |
|--------------|--------------|
| ![showcase sample](https://github.com/user-attachments/assets/e4b8fab9-bc67-4046-9db7-f0b2315c2668) | ![showcase sample 2](https://github.com/user-attachments/assets/9f62d153-8185-4d42-bb21-f6cac8cbef43) |
| ![showcase1](https://github.com/user-attachments/assets/302bbc7a-6c96-4101-a5e3-59877a4233b4)| ![showcase2](https://github.com/user-attachments/assets/9d074dcf-cf81-465f-b970-0d1f7eda766c) |

