### PR TITLE
Add custom font support to title & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 With **Showcase**, you can easily show tooltips. **Showcase** will highlight the view and show tooltip on it. You can
 customize title and description text fields, backgrounds and arrow positions. You can also find out how the user closed
-the showcase and in multi focus situations you can find out which view was clicked.
+the showcase and in multi focus situations you can find out which view was clicked. The library supports both system fonts
+and custom fonts for tooltip text, allowing you to maintain brand consistency across your app.
 
 ## Installation
 
@@ -40,7 +41,8 @@ val showcaseManager = ShowcaseManager.Builder()
     .titleText("Title about myView")  
     .titleTextSize(22F) 
     .titleTextColor(ContextCompat.getColor(this, R.color.blue)) 
-    .titleTextFontFamily("sans-serif-medium")  
+    .titleTextFontFamily("sans-serif-medium")  // Using system font
+    .titleTextFontFamilyResId(R.font.custom_font)  // Using custom font
     .titleTextStyle(Typeface.BOLD)  
     .descriptionText("Little bit info for my lovely myView")   
     .windowBackgroundAlpha(127)  
@@ -77,8 +79,10 @@ showcaseManager.show(context) // or showcaseManager.show(context, REQUEST_CODE_S
 | `builder.descriptionTextColor(Int)`                     | descriptionText's color                                                         | yes      | Color.BLACK                 | yes      |
 | `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                     | yes      | 18 SP                       | no       |
 | `builder.descriptionTextSize(Int)`                      | descriptionText's text size in SP                                               | yes      | 14 SP                       | no       |
-| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily                                                          | yes      | sans-serif                  | yes      |
-| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily                                                    | yes      | sans-serif                  | yes      |
+| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily (system fonts)                                           | yes      | sans-serif                  | yes      |
+| `builder.titleTextFontFamilyResId(Int)`                 | titleText's custom font resource ID                                             | yes      | null                        | yes      |
+| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily (system fonts)                                     | yes      | sans-serif                  | yes      |
+| `builder.descriptionTextFontFamilyResId(Int)`           | descriptionText's custom font resource ID                                       | yes      | null                        | yes      |
 | `builder.titleTextStyle(Int)`                           | titleText's textStyle                                                           | yes      | Typeface.NORMAL             | yes      |
 | `builder.descriptionTextStyle(Int)`                     | descriptionText's textStyle                                                     | yes      | Typeface.NORMAL             | yes      |
 | `builder.backgroundColor(Int)`                          | background color of tooltip                                                     | yes      | Color.WHITE                 | yes      |

--- a/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseManager.kt
+++ b/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseManager.kt
@@ -102,9 +102,13 @@ class ShowcaseManager private constructor(
                 showcaseModel.isShowcaseViewClickable
             ),
             titleTextFontFamily = typedArray.getString(R.styleable.Showcase_Theme_titleTextFontFamily) ?: showcaseModel.titleTextFontFamily,
+            titleTextFontFamilyResId = typedArray.getResourceId(R.styleable.Showcase_Theme_titleTextFontFamilyResId, 0)
+                .takeIf { it != 0 } ?: showcaseModel.titleTextFontFamilyResId,
             titleTextStyle = typedArray.getInteger(R.styleable.Showcase_Theme_titleStyle, showcaseModel.titleTextStyle),
             descriptionTextFontFamily = typedArray.getString(R.styleable.Showcase_Theme_descriptionTextFontFamily)
                 ?: showcaseModel.descriptionTextFontFamily,
+            descriptionTextFontFamilyResId = typedArray.getResourceId(R.styleable.Showcase_Theme_descriptionTextFontFamilyResId, 0)
+                .takeIf { it != 0 } ?: showcaseModel.descriptionTextFontFamilyResId,
             descriptionTextStyle = typedArray.getInteger(R.styleable.Showcase_Theme_descriptionTextStyle, showcaseModel.descriptionTextStyle)
         ).also {
             typedArray.recycle()
@@ -143,9 +147,11 @@ class ShowcaseManager private constructor(
         private var windowBackgroundAlpha: Int = Constants.DEFAULT_BACKGROUND_ALPHA
         private var titleTextSize: Float = Constants.DEFAULT_TITLE_TEXT_SIZE
         private var titleTextFontFamily: String = Constants.DEFAULT_TITLE_TEXT_FONT_FAMILY
+        private var titleTextFontFamilyResId: Int? = null
         private var titleTextStyle: Int = Constants.DEFAULT_TITLE_TEXT_STYLE
         private var descriptionTextSize: Float = Constants.DEFAULT_DESCRIPTION_TEXT_SIZE
         private var descriptionTextFontFamily: String = Constants.DEFAULT_DESCRIPTION_TEXT_FONT_FAMILY
+        private var descriptionTextFontFamilyResId: Int? = null
         private var descriptionTextStyle: Int = Constants.DEFAULT_DESCRIPTION_TEXT_STYLE
         private var highlightPadding: Float = Constants.DEFAULT_HIGHLIGHT_PADDING_EXTRA
 
@@ -184,6 +190,13 @@ class ShowcaseManager private constructor(
          * @param fontFamily assigns fontFamily to titleText
          */
         fun titleTextFontFamily(fontFamily: String) = apply { titleTextFontFamily = fontFamily }
+
+        /**
+         * Sets the title font family using a font resource ID
+         *
+         * @param resId font resId
+         */
+        fun titleTextFontFamilyResId(@FontRes resId: Int) = apply { titleTextFontFamilyResId = resId }
 
         /**
          * Controls whether showcase should be shown indefinitely or not. By default it is true.
@@ -228,6 +241,15 @@ class ShowcaseManager private constructor(
          */
         fun descriptionTextFontFamily(fontFamily: String) =
             apply { descriptionTextFontFamily = fontFamily }
+
+        /**
+         * Sets the description font family using a font resource ID
+         *
+         * @param resId font resId
+         */
+        fun descriptionTextFontFamilyResId(@FontRes resId: Int) = apply { 
+            descriptionTextFontFamilyResId = resId
+        }
 
         /**
          * Assign textStyle to descriptionText
@@ -371,9 +393,11 @@ class ShowcaseManager private constructor(
                 windowBackgroundAlpha = windowBackgroundAlpha,
                 titleTextSize = titleTextSize,
                 titleTextFontFamily = titleTextFontFamily,
+                titleTextFontFamilyResId = titleTextFontFamilyResId,
                 titleTextStyle = titleTextStyle,
                 descriptionTextSize = descriptionTextSize,
                 descriptionTextFontFamily = descriptionTextFontFamily,
+                descriptionTextFontFamilyResId = descriptionTextFontFamilyResId,
                 descriptionTextStyle = descriptionTextStyle,
                 highlightPadding = highlightPadding,
                 cancellableFromOutsideTouch = cancellableFromOutsideTouch,

--- a/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseModel.kt
+++ b/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseModel.kt
@@ -4,6 +4,7 @@ import android.graphics.RectF
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
+import androidx.annotation.FontRes
 import androidx.annotation.LayoutRes
 import com.trendyol.showcase.ui.slidablecontent.SlidableContent
 import com.trendyol.showcase.ui.showcase.HighlightType
@@ -31,9 +32,11 @@ data class ShowcaseModel(
     val windowBackgroundAlpha: Int,
     val titleTextSize: Float,
     val titleTextFontFamily: String,
+    @FontRes val titleTextFontFamilyResId: Int?,
     val titleTextStyle: Int,
     val descriptionTextSize: Float,
     val descriptionTextFontFamily: String,
+    @FontRes val descriptionTextFontFamilyResId: Int?,
     val descriptionTextStyle: Int,
     val highlightPadding: Float,
     val cancellableFromOutsideTouch: Boolean,

--- a/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContent.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContent.kt
@@ -2,6 +2,7 @@ package com.trendyol.showcase.ui.slidablecontent
 
 import android.os.Parcelable
 import androidx.annotation.ColorInt
+import androidx.annotation.FontRes
 import com.trendyol.showcase.ui.tooltip.TextPosition
 import kotlinx.parcelize.Parcelize
 
@@ -12,11 +13,13 @@ data class SlidableContent(
     @ColorInt var titleTextColor: Int,
     var titleTextSize: Float,
     var titleTextFontFamily: String,
+    @FontRes var titleTextFontFamilyResId: Int?,
     var titleTextStyle: Int,
     var description: String?,
     @ColorInt var descriptionTextColor: Int,
     var descriptionTextSize: Float,
     var descriptionTextFontFamily: String,
+    @FontRes var descriptionTextFontFamilyResId: Int?,
     var descriptionTextStyle: Int,
     var textPosition: TextPosition,
 ) : Parcelable

--- a/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentAdapter.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentAdapter.kt
@@ -1,6 +1,5 @@
 package com.trendyol.showcase.ui.slidablecontent
 
-import android.graphics.Typeface
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
@@ -37,10 +36,7 @@ internal class SlidableContentAdapter(private val slidableContentList: List<Slid
                 val viewState = SlidableContentViewState(item)
 
                 with(textViewTitle) {
-                    typeface = Typeface.create(
-                        viewState.slidableContent.titleTextFontFamily,
-                        viewState.slidableContent.titleTextStyle,
-                    )
+                    typeface = viewState.getTitleTypeface(context)
                     text = viewState.slidableContent.title
                     textAlignment = viewState.getTextPosition()
                     setTextColor(viewState.slidableContent.titleTextColor)
@@ -48,10 +44,7 @@ internal class SlidableContentAdapter(private val slidableContentList: List<Slid
                     setTextSizeInSp(viewState.slidableContent.titleTextSize)
                 }
                 with(textViewDescription) {
-                    typeface = Typeface.create(
-                        viewState.slidableContent.descriptionTextFontFamily,
-                        viewState.slidableContent.descriptionTextStyle,
-                    )
+                    typeface = viewState.getDescriptionTypeface(context)
                     text = viewState.slidableContent.description
                     textAlignment = viewState.getTextPosition()
                     setTextColor(viewState.slidableContent.descriptionTextColor)

--- a/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentDSL.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentDSL.kt
@@ -16,11 +16,13 @@ fun slidableContent(build: SlidableContent.() -> Unit): SlidableContent {
         titleTextColor = DEFAULT_TEXT_COLOR,
         titleTextSize = DEFAULT_TITLE_TEXT_SIZE,
         titleTextFontFamily = DEFAULT_TITLE_TEXT_FONT_FAMILY,
+        titleTextFontFamilyResId = null,
         titleTextStyle = DEFAULT_TITLE_TEXT_STYLE,
         description = null,
         descriptionTextColor = DEFAULT_TEXT_COLOR,
         descriptionTextSize = DEFAULT_DESCRIPTION_TEXT_SIZE,
         descriptionTextFontFamily = DEFAULT_DESCRIPTION_TEXT_FONT_FAMILY,
+        descriptionTextFontFamilyResId = null,
         descriptionTextStyle = DEFAULT_DESCRIPTION_TEXT_STYLE,
         textPosition = DEFAULT_TEXT_POSITION
     )

--- a/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentViewState.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/slidablecontent/SlidableContentViewState.kt
@@ -1,5 +1,8 @@
 package com.trendyol.showcase.ui.slidablecontent
 
+import android.content.Context
+import android.graphics.Typeface
+import androidx.core.content.res.ResourcesCompat
 import com.trendyol.showcase.ui.tooltip.TextPosition
 
 internal class SlidableContentViewState(val slidableContent: SlidableContent) {
@@ -14,5 +17,17 @@ internal class SlidableContentViewState(val slidableContent: SlidableContent) {
             TextPosition.END -> 3
             else -> 2
         }
+    }
+
+    fun getTitleTypeface(context: Context): Typeface? {
+        return slidableContent.titleTextFontFamilyResId?.let { resId ->
+            ResourcesCompat.getFont(context, resId)
+        } ?: Typeface.create(slidableContent.titleTextFontFamily, slidableContent.titleTextStyle)
+    }
+
+    fun getDescriptionTypeface(context: Context): Typeface? {
+        return slidableContent.descriptionTextFontFamilyResId?.let { resId ->
+            ResourcesCompat.getFont(context, resId)
+        } ?: Typeface.create(slidableContent.descriptionTextFontFamily, slidableContent.descriptionTextStyle)
     }
 }

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipView.kt
@@ -1,7 +1,6 @@
 package com.trendyol.showcase.ui.tooltip
 
 import android.content.Context
-import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
@@ -48,10 +47,7 @@ class TooltipView @JvmOverloads constructor(
     internal fun bind(tooltipViewState: TooltipViewState) {
         with(binding) {
             with(textViewTooltipTitle) {
-                typeface = Typeface.create(
-                    tooltipViewState.getTitleTextFontFamily(),
-                    tooltipViewState.getTitleTextStyle()
-                )
+                typeface = tooltipViewState.getTitleTypeface(context)
                 text = tooltipViewState.getTitle()
                 textAlignment = tooltipViewState.getTextPosition()
                 setTextColor(tooltipViewState.getTitleTextColor())
@@ -59,10 +55,7 @@ class TooltipView @JvmOverloads constructor(
                 setTextSizeInSp(tooltipViewState.getTitleTextSize())
             }
             with(textViewTooltipDescription) {
-                typeface = Typeface.create(
-                    tooltipViewState.getDescriptionTextFontFamily(),
-                    tooltipViewState.getDescriptionTextStyle()
-                )
+                typeface = tooltipViewState.getDescriptionTypeface(context)
                 text = tooltipViewState.getDescription()
                 textAlignment = tooltipViewState.getTextPosition()
                 setTextColor(tooltipViewState.getDescriptionTextColor())

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
@@ -1,6 +1,9 @@
 package com.trendyol.showcase.ui.tooltip
 
+import android.content.Context
+import android.graphics.Typeface
 import android.view.View
+import androidx.core.content.res.ResourcesCompat
 import com.trendyol.showcase.R
 import com.trendyol.showcase.showcase.ShowcaseModel
 import com.trendyol.showcase.util.Constants
@@ -88,4 +91,20 @@ internal data class TooltipViewState(
     fun isSlidableContentVisible() = showcaseModel.slidableContentList.isNullOrEmpty().not()
 
     fun isToolTipVisible() = showcaseModel.isToolTipVisible
+
+    fun getTitleTypeface(context: Context): Typeface? {
+        return showcaseModel.titleTextFontFamilyResId?.let { resId ->
+            ResourcesCompat.getFont(context, resId)
+        } ?: showcaseModel.titleTextFontFamily?.let { fontFamily ->
+            Typeface.create(fontFamily, showcaseModel.titleTextStyle)
+        }
+    }
+
+    fun getDescriptionTypeface(context: Context): Typeface? {
+        return showcaseModel.descriptionTextFontFamilyResId?.let { resId ->
+            ResourcesCompat.getFont(context, resId)
+        } ?: showcaseModel.descriptionTextFontFamily?.let { fontFamily ->
+            Typeface.create(fontFamily, showcaseModel.descriptionTextStyle)
+        }
+    }
 }

--- a/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/tooltip/TooltipViewState.kt
@@ -95,16 +95,12 @@ internal data class TooltipViewState(
     fun getTitleTypeface(context: Context): Typeface? {
         return showcaseModel.titleTextFontFamilyResId?.let { resId ->
             ResourcesCompat.getFont(context, resId)
-        } ?: showcaseModel.titleTextFontFamily?.let { fontFamily ->
-            Typeface.create(fontFamily, showcaseModel.titleTextStyle)
-        }
+        } ?: Typeface.create(showcaseModel.titleTextFontFamily, showcaseModel.titleTextStyle)
     }
 
     fun getDescriptionTypeface(context: Context): Typeface? {
         return showcaseModel.descriptionTextFontFamilyResId?.let { resId ->
             ResourcesCompat.getFont(context, resId)
-        } ?: showcaseModel.descriptionTextFontFamily?.let { fontFamily ->
-            Typeface.create(fontFamily, showcaseModel.descriptionTextStyle)
-        }
+        } ?: Typeface.create(showcaseModel.descriptionTextFontFamily, showcaseModel.descriptionTextStyle)
     }
 }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -4,8 +4,10 @@
     <declare-styleable name="Showcase.Theme">
         <attr name="titleTextColor" format="color" />
         <attr name="titleTextFontFamily" format="string" />
+        <attr name="titleTextFontFamilyResId" format="reference" />
         <attr name="titleStyle" format="integer" />
         <attr name="descriptionTextFontFamily" format="string" />
+        <attr name="descriptionTextFontFamilyResId" format="reference" />
         <attr name="descriptionTextStyle" format="integer" />
         <attr name="descriptionTextColor" format="color" />
         <attr name="closeButtonColor" format="color" />

--- a/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateFactory.kt
+++ b/library/src/test/java/com/trendyol/showcase/ui/tooltip/TooltipViewStateFactory.kt
@@ -62,11 +62,13 @@ internal object TooltipViewStateFactory {
             radiusBottomStart = 0F,
             radiusTopEnd = 0F,
             descriptionTextFontFamily = "sans-serif",
+            descriptionTextFontFamilyResId = null,
             isToolTipVisible = true,
             slidableContentList = listOf(),
             titleTextStyle = Typeface.BOLD,
             descriptionTextStyle = Typeface.NORMAL,
             titleTextFontFamily = "sans-serif",
+            titleTextFontFamilyResId = null,
             showDuration = 2000L,
             isShowcaseViewVisibleIndefinitely = true,
             isArrowVisible = isArrowVisible


### PR DESCRIPTION
# Add Support for Custom Fonts in Showcase Tooltips

## Problem
Currently, the Showcase library only supports built-in system fonts (e.g., "sans-serif", "serif") for tooltip titles and descriptions. This limitation prevents developers from using custom fonts in their tooltips.

## Solution
This MR adds support for custom fonts in Showcase tooltips by:
- Adding new attributes `titleTextFontFamilyResId` and `descriptionTextFontFamilyResId` to support font resources
- Implementing font loading using `ResourcesCompat.getFont()` for resource-based fonts
- Maintaining backward compatibility with existing string-based font family support
- Adding proper null handling and fallback mechanisms

## Technical Details
- Added new reference-type attributes in `attrs.xml` for font resources
- Updated `ShowcaseModel` and `SlidableContent` to support both string and resource-based font families
- Implemented font loading logic in `TooltipViewState` and `SlidableContentViewState`
- Added builder methods in `ShowcaseManager.Builder` for setting custom fonts

## Usage Example
```kotlin
ShowcaseManager.Builder()
    .titleTextFontFamilyResId(R.font.custom_font) // Using custom font
    .descriptionTextFontFamily("sans-serif") // Using system font
    .build()
```