### PR TITLE
Add cancellableFromScroll flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,18 @@
 
 <img src="screenshots/1.png" width="240"/>    <img src="screenshots/2.png" width="240"/>    <img src="screenshots/3.png" width="240"/>    <img src="screenshots/4.png" width="240"/>    <img src="screenshots/5.png" width="240"/>   <img src="screenshots/6.png" width="240"/>
 
-With **Showcase**, you can easily show tooltips. **Showcase** will highlight the view and show tooltip on it. You can
-customize title and description text fields, backgrounds and arrow positions. You can also find out how the user closed
-the showcase and in multi focus situations you can find out which view was clicked. The library supports both system fonts
+With **Showcase**, you can easily show tooltips. **Showcase** will highlight the view and show
+tooltip on it. You can
+customize title and description text fields, backgrounds and arrow positions. You can also find out
+how the user closed
+the showcase and in multi focus situations you can find out which view was clicked. The library
+supports both system fonts
 and custom fonts for tooltip text, allowing you to maintain brand consistency across your app.
 
 ## Installation
 
-- To implement **Showcase** to your Android project via Gradle, you need to add Jitpack repository to your
+- To implement **Showcase** to your Android project via Gradle, you need to add Jitpack repository
+  to your
   root `build.gradle`.
 
 ```
@@ -23,7 +27,8 @@ allprojects {
 }
 ```
 
-- After adding Jitpack repository, you can add **Showcase** dependency to your app level `build.gradle`.
+- After adding Jitpack repository, you can add **Showcase** dependency to your app level
+  `build.gradle`.
 
 ```
 dependencies {
@@ -68,56 +73,58 @@ showcaseManager.show(context) // or showcaseManager.show(context, REQUEST_CODE_S
 
 ### Builder Configuration
 
-| Usage                                                   | Description                                                                     | Optional | Default Value               | StyleRes |
-|:--------------------------------------------------------|:--------------------------------------------------------------------------------|:---------|:----------------------------|:---------|
-| `builder.focus(View)`                                   | view to be focused on                                                           | no       | null                        | no       |
-| `builder.focus(Array<View>)`                            | view array to be focused on                                                     | no       | null                        | no       |
-| `builder.resId(Int)`                                    | Showcase.Theme style                                                            | yes      | null                        | yes      |
-| `builder.titleText(String)`                             | text to be showed on top of the tooltip                                         | yes      | ""                          | no       |
-| `builder.descriptionText(String)`                       | description text will be displayed on tooltip                                   | yes      | ""                          | no       |
-| `builder.titleTextColor(Int)`                           | titleText's color                                                               | yes      | Color.BLACK                 | yes      |
-| `builder.descriptionTextColor(Int)`                     | descriptionText's color                                                         | yes      | Color.BLACK                 | yes      |
-| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                     | yes      | 18 SP                       | no       |
-| `builder.descriptionTextSize(Int)`                      | descriptionText's text size in SP                                               | yes      | 14 SP                       | no       |
-| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily (system fonts)                                           | yes      | sans-serif                  | yes      |
-| `builder.titleTextFontFamilyResId(Int)`                 | titleText's custom font resource ID                                             | yes      | null                        | yes      |
-| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily (system fonts)                                     | yes      | sans-serif                  | yes      |
-| `builder.descriptionTextFontFamilyResId(Int)`           | descriptionText's custom font resource ID                                       | yes      | null                        | yes      |
-| `builder.titleTextStyle(Int)`                           | titleText's textStyle                                                           | yes      | Typeface.NORMAL             | yes      |
-| `builder.descriptionTextStyle(Int)`                     | descriptionText's textStyle                                                     | yes      | Typeface.NORMAL             | yes      |
-| `builder.backgroundColor(Int)`                          | background color of tooltip                                                     | yes      | Color.WHITE                 | yes      |
-| `builder.closeButtonColor(Int)`                         | closeButton's color                                                             | yes      | Color.BLACK                 | yes      |
-| `builder.showCloseButton(Boolean)`                      | show close button on tooltip                                                    | yes      | true                        | yes      |
-| `builder.setArrowVisibility(Boolean)`                   | controls whether arrow icon should be shown or not                              | yes      | true                        | no       |
-| `builder.arrowResource(Int)`                            | custom icon resource for the arrow rotates 180° if the arrow position is bottom | yes      | ic_arrow_up                 | no       |
-| `builder.arrowPosition(ArrowPosition)`                  | arrow can be placed under or over the tooltip                                   | yes      | ArrowPosition.AUTO          | no       |
-| `builder.arrowPercentage(Int)`                          | arrow position percentage can be decided                                        | yes      | null                        | no       |
-| `builder.highlightType(HighlightType)`                  | view can be highlighted with a circle shape or rectangle                        | yes      | HighlightType.RECTANGLE     | no       |
-| `builder.cancelListener(CancelListener)`                | will be called after user quit from tooltip                                     | yes      | null                        | no       |
-| `builder.windowBackgroundColor(Int)`                    | background of the window's color can be decided                                 | yes      | Color.BLACK                 | yes      |
-| `builder.windowBackgroundTint(Int)`                     | alpha value of window's background color                                        | yes      | 204                         | no       |
-| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                     | yes      | 18                          | no       |
-| `builder.cancellableFromOutsideTouch(Boolean)`          | outside touch from tooltip will act as close click                              | yes      | false                       | yes      |
-| `builder.showcaseViewClickable(Boolean)`                | makes the showcase view clickable or not                                        | yes      | false                       | yes      |
-| `builder.isDebugMode(Boolean)`                          | tooltip won't be presented                                                      | yes      | false                       | no       |
-| `builder.attachOnParentLifecycle(Boolean)`              | observe parent lifecycle and dismiss showcase                                   | yes      | false                       | no       |
-| `builder.textPosition(TextPosition)`                    | text can be positioning center, end and start                                   | yes      | TextPosition.START          | no       |
-| `builder.imageUrl(String)`                              | show image on tooltip                                                           | yes      | null                        | no       |
-| `builder.customContent(Int)`                            | show given layout                                                               | yes      | null                        | no       |
-| `builder.statusBarVisible(Boolean)`                     | statusBar visibility of window                                                  | yes      | true                        | no       |
-| `builder.toolTipVisible(Boolean)`                       | tooltip visibility                                                              | yes      | true                        | no       |
-| `builder.highlightRadius(Float, Float, Float, Float)`   | tooltip visibility                                                              | yes      | 0f, 0f, 0f, 0f              | no       |
-| `builder.setSlidableContentList(List<SlidableContent>)` | show slidable content                                                           | yes      | null                        | no       |  
-| `builder.showDurationMillis(Long)`                      | duration of the tooltip visibility                                              | yes      | 2000L                       | no       |
-| `builder.showcaseViewVisibleIndefinitely(Boolean)`      | controls tooltip visibility condition                                           | yes      | true                        | no       |
-| `builder.build()`                                       | will return ShowcaseManager instance                                            | no       |                             |          |
-| `showcaseManager.show(Context)`                         | show the tooltip with set attributes on                                         | no       |                             |          |
+| Usage                                                   | Description                                                                     | Optional | Default Value           | StyleRes |
+|:--------------------------------------------------------|:--------------------------------------------------------------------------------|:---------|:------------------------|:---------|
+| `builder.focus(View)`                                   | view to be focused on                                                           | no       | null                    | no       |
+| `builder.focus(Array<View>)`                            | view array to be focused on                                                     | no       | null                    | no       |
+| `builder.resId(Int)`                                    | Showcase.Theme style                                                            | yes      | null                    | yes      |
+| `builder.titleText(String)`                             | text to be showed on top of the tooltip                                         | yes      | ""                      | no       |
+| `builder.descriptionText(String)`                       | description text will be displayed on tooltip                                   | yes      | ""                      | no       |
+| `builder.titleTextColor(Int)`                           | titleText's color                                                               | yes      | Color.BLACK             | yes      |
+| `builder.descriptionTextColor(Int)`                     | descriptionText's color                                                         | yes      | Color.BLACK             | yes      |
+| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                     | yes      | 18 SP                   | no       |
+| `builder.descriptionTextSize(Int)`                      | descriptionText's text size in SP                                               | yes      | 14 SP                   | no       |
+| `builder.titleTextFontFamily(String)`                   | titleText's fontFamily (system fonts)                                           | yes      | sans-serif              | yes      |
+| `builder.titleTextFontFamilyResId(Int)`                 | titleText's custom font resource ID                                             | yes      | null                    | yes      |
+| `builder.descriptionTextFontFamily(String)`             | descriptionText's fontFamily (system fonts)                                     | yes      | sans-serif              | yes      |
+| `builder.descriptionTextFontFamilyResId(Int)`           | descriptionText's custom font resource ID                                       | yes      | null                    | yes      |
+| `builder.titleTextStyle(Int)`                           | titleText's textStyle                                                           | yes      | Typeface.NORMAL         | yes      |
+| `builder.descriptionTextStyle(Int)`                     | descriptionText's textStyle                                                     | yes      | Typeface.NORMAL         | yes      |
+| `builder.backgroundColor(Int)`                          | background color of tooltip                                                     | yes      | Color.WHITE             | yes      |
+| `builder.closeButtonColor(Int)`                         | closeButton's color                                                             | yes      | Color.BLACK             | yes      |
+| `builder.showCloseButton(Boolean)`                      | show close button on tooltip                                                    | yes      | true                    | yes      |
+| `builder.setArrowVisibility(Boolean)`                   | controls whether arrow icon should be shown or not                              | yes      | true                    | no       |
+| `builder.arrowResource(Int)`                            | custom icon resource for the arrow rotates 180° if the arrow position is bottom | yes      | ic_arrow_up             | no       |
+| `builder.arrowPosition(ArrowPosition)`                  | arrow can be placed under or over the tooltip                                   | yes      | ArrowPosition.AUTO      | no       |
+| `builder.arrowPercentage(Int)`                          | arrow position percentage can be decided                                        | yes      | null                    | no       |
+| `builder.highlightType(HighlightType)`                  | view can be highlighted with a circle shape or rectangle                        | yes      | HighlightType.RECTANGLE | no       |
+| `builder.cancelListener(CancelListener)`                | will be called after user quit from tooltip                                     | yes      | null                    | no       |
+| `builder.windowBackgroundColor(Int)`                    | background of the window's color can be decided                                 | yes      | Color.BLACK             | yes      |
+| `builder.windowBackgroundTint(Int)`                     | alpha value of window's background color                                        | yes      | 204                     | no       |
+| `builder.titleTextSize(Int)`                            | titleText's text size in SP                                                     | yes      | 18                      | no       |
+| `builder.cancellableFromOutsideTouch(Boolean)`          | outside touch from tooltip will act as close click                              | yes      | false                   | yes      |
+| `builder.cancellableFromScroll(Boolean)`                | screen scroll will act as close click                                           | yes      | false                   | yes      |
+| `builder.showcaseViewClickable(Boolean)`                | makes the showcase view clickable or not                                        | yes      | false                   | yes      |
+| `builder.isDebugMode(Boolean)`                          | tooltip won't be presented                                                      | yes      | false                   | no       |
+| `builder.attachOnParentLifecycle(Boolean)`              | observe parent lifecycle and dismiss showcase                                   | yes      | false                   | no       |
+| `builder.textPosition(TextPosition)`                    | text can be positioning center, end and start                                   | yes      | TextPosition.START      | no       |
+| `builder.imageUrl(String)`                              | show image on tooltip                                                           | yes      | null                    | no       |
+| `builder.customContent(Int)`                            | show given layout                                                               | yes      | null                    | no       |
+| `builder.statusBarVisible(Boolean)`                     | statusBar visibility of window                                                  | yes      | true                    | no       |
+| `builder.toolTipVisible(Boolean)`                       | tooltip visibility                                                              | yes      | true                    | no       |
+| `builder.highlightRadius(Float, Float, Float, Float)`   | tooltip visibility                                                              | yes      | 0f, 0f, 0f, 0f          | no       |
+| `builder.setSlidableContentList(List<SlidableContent>)` | show slidable content                                                           | yes      | null                    | no       |  
+| `builder.showDurationMillis(Long)`                      | duration of the tooltip visibility                                              | yes      | 2000L                   | no       |
+| `builder.showcaseViewVisibleIndefinitely(Boolean)`      | controls tooltip visibility condition                                           | yes      | true                    | no       |
+| `builder.build()`                                       | will return ShowcaseManager instance                                            | no       |                         |          |
+| `showcaseManager.show(Context)`                         | show the tooltip with set attributes on                                         | no       |                         |          |
 
 ### Action Result
 
 By overriding `onActivityResult` you can get feedback based on the types in the ActionType class.
 
-If the actionType is `HIGHLIGHT_CLICKED`, the `KEY_SELECTED_VIEW_INDEX` parameter returns the index of the clicked view.
+If the actionType is `HIGHLIGHT_CLICKED`, the `KEY_SELECTED_VIEW_INDEX` parameter returns the index
+of the clicked view.
 If no view is clicked, the index will be -1.
 
 ```

--- a/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseManager.kt
+++ b/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseManager.kt
@@ -159,6 +159,7 @@ class ShowcaseManager private constructor(
         private var resId: Int? = null
         private var cancellableFromOutsideTouch: Boolean =
             Constants.DEFAULT_CANCELLABLE_FROM_OUTSIDE_TOUCH
+        private var cancellableFromScroll: Boolean = Constants.DEFAULT_CANCELLABLE_FROM_SCROLL
         private var isShowcaseViewClickable: Boolean = Constants.DEFAULT_SHOWCASE_VIEW_CLICKABLE
         private var isDebugMode: Boolean = false
         private var textPosition: TextPosition = Constants.DEFAULT_TEXT_POSITION
@@ -307,6 +308,8 @@ class ShowcaseManager private constructor(
 
         fun cancellableFromOutsideTouch(cancellable: Boolean) = apply { cancellableFromOutsideTouch = cancellable }
 
+        fun cancellableFromScroll(cancellable: Boolean) = apply { cancellableFromScroll = cancellable }
+
         /**
          * Makes the showcase view clickable or not.
          *
@@ -401,6 +404,7 @@ class ShowcaseManager private constructor(
                 descriptionTextStyle = descriptionTextStyle,
                 highlightPadding = highlightPadding,
                 cancellableFromOutsideTouch = cancellableFromOutsideTouch,
+                cancellableFromScroll = cancellableFromScroll,
                 isShowcaseViewClickable = isShowcaseViewClickable,
                 isDebugMode = isDebugMode,
                 textPosition = textPosition,

--- a/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseModel.kt
+++ b/library/src/main/java/com/trendyol/showcase/showcase/ShowcaseModel.kt
@@ -40,6 +40,7 @@ data class ShowcaseModel(
     val descriptionTextStyle: Int,
     val highlightPadding: Float,
     val cancellableFromOutsideTouch: Boolean,
+    val cancellableFromScroll: Boolean,
     val isShowcaseViewClickable: Boolean,
     val isDebugMode: Boolean,
     val textPosition: TextPosition,

--- a/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
@@ -142,6 +142,11 @@ class ShowcaseView @JvmOverloads constructor(
                     sendActionType(ActionType.EXIT)
                 }
             }
+            scrollListener = { view, startX, startY, endX, endY ->
+                if (showcaseModel?.cancellableFromScroll == true) {
+                    sendActionType(ActionType.EXIT)
+                }
+            }
         }.also {
             setOnTouchListener(it)
         }

--- a/library/src/main/java/com/trendyol/showcase/util/Constants.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/Constants.kt
@@ -29,6 +29,7 @@ object Constants {
     val DEFAULT_HIGHLIGHT_TYPE = HighlightType.RECTANGLE
     val DEFAULT_TEXT_POSITION = TextPosition.START
     const val DEFAULT_CANCELLABLE_FROM_OUTSIDE_TOUCH = false
+    const val DEFAULT_CANCELLABLE_FROM_SCROLL = false
     const val DEFAULT_SHOWCASE_VIEW_CLICKABLE = false
     const val DEFAULT_HIGHLIGHT_RADIUS = 0f
 }

--- a/library/src/main/java/com/trendyol/showcase/util/OnTouchClickListener.kt
+++ b/library/src/main/java/com/trendyol/showcase/util/OnTouchClickListener.kt
@@ -14,6 +14,7 @@ class OnTouchClickListener(private val minMove: Int = 10) : View.OnTouchListener
     private var startY: Float = 0f
 
     var clickListener: ((v: View, x: Float, y: Float) -> Unit)? = null
+    var scrollListener: ((v: View, startX: Float, startY: Float, endX: Float, endY: Float) -> Unit)? = null
 
     private fun isAClick(startX: Float, endX: Float, startY: Float, endY: Float): Boolean {
         val differenceX = abs(startX - endX)
@@ -33,8 +34,10 @@ class OnTouchClickListener(private val minMove: Int = 10) : View.OnTouchListener
                 val endY = event.y
                 if (isAClick(startX, endX, startY, endY)) {
                     clickListener?.invoke(v, event.x, event.y)
-                    return true
+                } else {
+                    scrollListener?.invoke(v, startX, startY, endX, endY)
                 }
+                return true
             }
         }
         return false

--- a/sample/src/main/java/com/trendyol/sample/SampleFragment.kt
+++ b/sample/src/main/java/com/trendyol/sample/SampleFragment.kt
@@ -112,6 +112,7 @@ class SampleFragment : Fragment() {
                     )
                     .showCloseButton(true)
                     .cancellableFromOutsideTouch(true)
+                    .cancellableFromScroll(true)
                     .arrowPosition(ArrowPosition.AUTO)
                     .highlightType(HighlightType.RECTANGLE)
                     .textPosition(TextPosition.START)
@@ -187,6 +188,7 @@ class SampleFragment : Fragment() {
                         bottomStartRadius = 16f
                     )
                     .cancellableFromOutsideTouch(true)
+                    .cancellableFromScroll(true)
                     .toolTipVisible(false)
                     .statusBarVisible(isStatusBarVisible)
                     .build()


### PR DESCRIPTION
Add scroll detection to ShowcaseView

- Add cancellableFromScroll flag to ShowcaseModel
- Update OnTouchClickListener to handle scroll events
- Exit showcase when scroll is detected if cancellableFromScroll is true

This change allows the showcase to be dismissed when the user performs a scroll gesture, providing a more natural interaction pattern.