### PR TITLE
Apply bottom padding to ShowcaseView if device lower than Android 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ allprojects {
 
 ```
 dependencies {
-    implementation "com.github.trendyol::showcase:2.0.2"
+    implementation "com.github.trendyol::showcase:2.0.9"
 }
 ```
 

--- a/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
+++ b/library/src/main/java/com/trendyol/showcase/ui/showcase/ShowcaseView.kt
@@ -3,6 +3,7 @@ package com.trendyol.showcase.ui.showcase
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.RectF
+import android.os.Build
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -45,7 +46,7 @@ class ShowcaseView @JvmOverloads constructor(
             // Always apply the same padding regardless of API level
             view.updatePadding(
                 top = systemBars.top,
-                bottom = systemBars.bottom,
+                bottom = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) 0 else systemBars.bottom,
                 left = systemBars.left,
                 right = systemBars.right
             )


### PR DESCRIPTION
Library was applying bottom padding for Android 15+ unnecessarily. This change applies bottom padding only when Android 14 or below.